### PR TITLE
Android intent filters

### DIFF
--- a/caches/schema-29.0.0.json
+++ b/caches/schema-29.0.0.json
@@ -712,6 +712,21 @@
                 }
               }
             }
+          },
+          "intentFilters": {
+            "description": "An array of intent filters.",
+            "example": [{
+              "action": "VIEW",
+              "data": {
+                "scheme": "https",
+                "host": "*.expo.io"
+              },
+              "category": [
+                "BROWSABLE",
+                "DEFAULT"
+              ]
+            }],
+            "type": "array"
           }
         },
         "additionalProperties": false

--- a/caches/schema-29.0.0.json
+++ b/caches/schema-29.0.0.json
@@ -726,7 +726,32 @@
                 "DEFAULT"
               ]
             }],
-            "type": "array"
+            "type": "array",
+            "uniqueItems": true,
+            "items": [
+              {
+                "type": "object",
+                "properties": {
+                  "action": { "type": "string" },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "scheme": { "type": "string" },
+                      "host": { "type": "string" },
+                      "port": { "type": "string" },
+                      "path": { "type": "string" },
+                      "pathPattern": { "type": "string" },
+                      "pathPrefix": { "type": "string" },
+                      "mimeType": { "type": "string" }
+                    },
+                    "additionalProperties": false
+                  },
+                  "category": { "type": ["array", "string"] }
+                },
+                "additionalProperties": false,
+                "required": ["action"]
+              }
+            ]
           }
         },
         "additionalProperties": false

--- a/src/__tests__/detach/AndroidIntentFilters-test.js
+++ b/src/__tests__/detach/AndroidIntentFilters-test.js
@@ -13,6 +13,7 @@ describe('renderIntentFilters', () => {
         'category': 'DEFAULT',
       },
       {
+        'autoVerify': true,
         'data': [
           { 'scheme': 'http', 'host': 'exp.host', 'pathPrefix': '/@', 'mimeType': 'image/jpeg' },
           { 'scheme': 'https', 'port': '443', 'pathPattern': '.*' },
@@ -28,7 +29,7 @@ describe('renderIntentFilters', () => {
           <action android:name="android.intent.action.VIEW"/>
           <category android:name="android.intent.category.DEFAULT"/>
         </intent-filter>`,
-        `<intent-filter>
+        `<intent-filter android:autoVerify="true">
           <data android:scheme="http" android:host="exp.host" android:pathPrefix="/@" android:mimeType="image/jpeg"/>
           <data android:scheme="https" android:port="443" android:pathPattern=".*"/>
           <action android:name="android.intent.action.WEB_SEARCH"/>

--- a/src/__tests__/detach/AndroidIntentFilters-test.js
+++ b/src/__tests__/detach/AndroidIntentFilters-test.js
@@ -1,0 +1,40 @@
+import renderIntentFilters from '../../detach/AndroidIntentFilters';
+
+function normalizeWhitespace(intentFiltersRendering) {
+  return intentFiltersRendering.map(intentFilter => intentFilter.replace(/>\s+</g, '>\n<'));
+}
+
+describe('renderIntentFilters', () => {
+  it('renders intent filters', () => {
+    const intentFilters = [
+      {
+        'data': { 'scheme': 'https' },
+        'action': 'VIEW',
+        'category': 'DEFAULT',
+      },
+      {
+        'data': [
+          { 'scheme': 'http', 'host': 'exp.host', 'pathPrefix': '/@', 'mimeType': 'image/jpeg' },
+          { 'scheme': 'https', 'port': '443', 'pathPattern': '.*' },
+        ],
+        'action': 'WEB_SEARCH',
+        'category': ['DEFAULT', 'BROWSABLE']
+      }
+    ];
+    expect(normalizeWhitespace(renderIntentFilters(intentFilters)))
+      .toEqual(normalizeWhitespace([
+        `<intent-filter>
+          <data android:scheme="https"/>
+          <action android:name="android.intent.action.VIEW"/>
+          <category android:name="android.intent.category.DEFAULT"/>
+        </intent-filter>`,
+        `<intent-filter>
+          <data android:scheme="http" android:host="exp.host" android:pathPrefix="/@" android:mimeType="image/jpeg"/>
+          <data android:scheme="https" android:port="443" android:pathPattern=".*"/>
+          <action android:name="android.intent.action.WEB_SEARCH"/>
+          <category android:name="android.intent.category.DEFAULT"/>
+          <category android:name="android.intent.category.BROWSABLE"/>
+        </intent-filter>`,
+      ]));
+  });
+});

--- a/src/detach/AndroidIntentFilters.js
+++ b/src/detach/AndroidIntentFilters.js
@@ -15,7 +15,9 @@ export default function renderIntentFilters(intentFilters) {
   //   ...
   // ]
   return intentFilters.map(intentFilter => {
-    return `<intent-filter>
+    const autoVerify = intentFilter.autoVerify ? ' android:autoVerify="true"' : '';
+
+    return `<intent-filter${autoVerify}>
       ${renderIntentFilterData(intentFilter.data)}
       <action android:name="android.intent.action.${intentFilter.action}"/>
       ${renderIntentFilterCategory(intentFilter.category)}

--- a/src/detach/AndroidIntentFilters.js
+++ b/src/detach/AndroidIntentFilters.js
@@ -1,0 +1,40 @@
+import _ from 'lodash';
+
+export default function renderIntentFilters(intentFilters) {
+  // returns an array of <intent-filter> tags:
+  // [
+  //   `<intent-filter>
+  //     <data android:scheme="exp"/>
+  //     <data android:scheme="exps"/>
+  //
+  //     <action android:name="android.intent.action.VIEW"/>
+  //
+  //     <category android:name="android.intent.category.DEFAULT"/>
+  //     <category android:name="android.intent.category.BROWSABLE"/>
+  //   </intent-filter>`,
+  //   ...
+  // ]
+  return intentFilters.map(intentFilter => {
+    return `<intent-filter>
+      ${renderIntentFilterData(intentFilter.data)}
+      <action android:name="android.intent.action.${intentFilter.action}"/>
+      ${renderIntentFilterCategory(intentFilter.category)}
+    </intent-filter>`;
+  });
+};
+
+function renderIntentFilterDatumEntries(datum) {
+  return _.toPairs(datum).map(entry => `android:${entry[0]}=\"${entry[1]}\"`).join(' ');
+}
+
+function renderIntentFilterData(data) {
+  return (Array.isArray(data) ? data : [data]).map(datum =>
+    `<data ${renderIntentFilterDatumEntries(datum)}/>`
+  ).join('\n');
+}
+
+function renderIntentFilterCategory(category) {
+  return (Array.isArray(category) ? category : [category]).map(cat =>
+    `<category android:name="android.intent.category.${cat}"/>`
+  ).join('\n');
+}

--- a/src/detach/AndroidShellApp.js
+++ b/src/detach/AndroidShellApp.js
@@ -719,10 +719,16 @@ export async function runShellAppModificationsAsync(
   }
 
   // Add app-specific intent filters
-  if (_.get(manifest, 'android.intentFilters')) {
-    var intentFilters = _.get(manifest, 'android.intentFilters');
+  var intentFilters = _.get(manifest, 'android.intentFilters');
+  if (isDetached) {
     await regexFileAsync(
-      '<!-- APP SPECIFIC INTENT FILTERS -->',
+      '<!-- ADD DETACH APP SPECIFIC INTENT FILTERS -->',
+      renderIntentFilters(intentFilters).join('\n'),
+      path.join(shellPath, 'app', 'src', 'main', 'AndroidManifest.xml')
+    );
+  } else {
+    await regexFileAsync(
+      '<!-- ADD SHELL APP SPECIFIC INTENT FILTERS -->',
       renderIntentFilters(intentFilters).join('\n'),
       path.join(shellPath, 'app', 'src', 'main', 'AndroidManifest.xml')
     );

--- a/src/detach/AndroidShellApp.js
+++ b/src/detach/AndroidShellApp.js
@@ -15,6 +15,7 @@ import * as AssetBundle from './AssetBundle';
 import * as ExponentTools from './ExponentTools';
 import StandaloneBuildFlags from './StandaloneBuildFlags';
 import StandaloneContext from './StandaloneContext';
+import renderIntentFilters from './AndroidIntentFilters';
 import logger from './Logger';
 
 const {
@@ -713,6 +714,16 @@ export async function runShellAppModificationsAsync(
 
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>`,
+      path.join(shellPath, 'app', 'src', 'main', 'AndroidManifest.xml')
+    );
+  }
+
+  // Add app-specific intent filters
+  if (_.get(manifest, 'android.intentFilters')) {
+    var intentFilters = _.get(manifest, 'android.intentFilters');
+    await regexFileAsync(
+      '<!-- APP SPECIFIC INTENT FILTERS -->',
+      renderIntentFilters(intentFilters).join('\n'),
       path.join(shellPath, 'app', 'src', 'main', 'AndroidManifest.xml')
     );
   }


### PR DESCRIPTION
Allows developers to specify an array of `intentFilters` in the `android` part of `app.json`.

```json
{
  "expo": {
    ...
    "android": {
      "intentFilters": [
        {
          "action": "VIEW",
          "data": {
            "scheme": "https",
            "host": "*.aha.io"
          },
          "category": [
            "BROWSABLE",
            "DEFAULT"
          ]
        }
      ]
    },
    ...
  }
}
```